### PR TITLE
Added basic http auth middleware for GraphQL routes.

### DIFF
--- a/deployment.yaml
+++ b/deployment.yaml
@@ -3,6 +3,7 @@ git:
     branch: master
 
 secrets:
+    - ADMIN_KEY_SECRET
     - TWITTER_CONSUMER_KEY
     - TWITTER_CONSUMER_SECRET
     - TWITTER_HACKGT_ACCESS_TOKEN

--- a/server/app.ts
+++ b/server/app.ts
@@ -10,6 +10,7 @@ import { mediaAPI } from './plugins';
 import { GenericNotifier } from './plugins/GenericNotifier';
 import { APIReturn } from './plugins/APIReturn';
 import typeDefs from './typeDefs';
+import { isAdmin } from "./middleware";
 
 const app = express();
 
@@ -71,7 +72,14 @@ const schema = makeExecutableSchema({ typeDefs,
 	resolvers
 });
 
-app.use('/graphql', bodyParser.json(), graphqlExpress({ schema }));
+app.use(
+	'/graphql',
+	bodyParser.json(),
+	isAdmin,
+	graphqlExpress({
+		schema
+	})
+);
 app.use('/graphiql', graphiqlExpress({ endpointURL: '/graphql' }));
 
 // Run plugin setup

--- a/server/common.ts
+++ b/server/common.ts
@@ -1,5 +1,14 @@
 export const PORT = process.env.PORT? parseInt(process.env.PORT, 10): 3000;
 
+// A secret that gives admin access to the service.
+// TODO: add user accounts n' such
+export const ADMIN_KEY_SECRET: string = (() => {
+	if (!process.env.ADMIN_KEY_SECRET) {
+		throw new Error("Must have admin key set in `ADMIN_KEY_SECRET`.");
+	}
+	return process.env.ADMIN_KEY_SECRET;
+})();
+
 // Some utility functions
 export const upperCamel = (before: string): string => before.split('_').map(w => w.slice(0,1).toUpperCase() + w.slice(1)).join('');
 

--- a/server/middleware.ts
+++ b/server/middleware.ts
@@ -1,0 +1,29 @@
+import * as express from "express";
+
+import { ADMIN_KEY_SECRET } from "./common";
+
+export function isAdmin(
+	request: express.Request,
+	response: express.Response,
+	next: express.NextFunction
+) {
+	response.setHeader("Cache-Control", "private");
+	const auth = request.headers.authorization;
+
+	if (auth && typeof auth === "string" && auth.indexOf(" ") > -1) {
+		const key = new Buffer(auth.split(" ")[1], "base64").toString();
+		if (key === ADMIN_KEY_SECRET) {
+			next();
+		}
+		else {
+			response.status(401).json({
+				"error": "Incorrect auth token!"
+			});
+		}
+	}
+	else {
+		response.status(401).json({
+			"error": "No auth token!"
+		});
+	}
+}


### PR DESCRIPTION
This is a super simple auth pass so we can:

1. Store real API keys in the cluster tied to this service.
2. Connect the BotGT UI to this service.

Basically you have to add a header to all GraphQL requests:
```http
Authorization: Basic <base64 of the admin key>
```